### PR TITLE
Went back to throwing real 500s

### DIFF
--- a/src/main/clojure/lead/api.clj
+++ b/src/main/clojure/lead/api.clj
@@ -58,9 +58,15 @@
   (let [results (core/eval-targets targets opts)
         exceptions (:exceptions @core/*context*)
         exception-details (map transform-exception exceptions)]
-    {:opts opts
-     :results results
-     :exceptions exception-details}))
+    (if (> (count exception-details)
+           0)
+      {:status 500
+       :opts opts
+       :results results
+       :exceptions exception-details}
+      {:opts opts
+       :results results
+       :exceptions exception-details})))
 
 (defroutes handler
   (GET "/find" [query]


### PR DESCRIPTION
Basically this comes down to not splitting how the app returns errors.
Having errors that are 200s and labeled in the body rather than having them be 500s
makes things unclear; for users, and makes it more difficult for them to handle the errors.
